### PR TITLE
treble_arm64_bvn: don't use device codename as product name for treble build

### DIFF
--- a/treble_arm64_bvN.mk
+++ b/treble_arm64_bvN.mk
@@ -8,7 +8,7 @@ $(call inherit-product, device/phh/treble/base.mk)
 $(call inherit-product, device/phh/treble/crdroid.mk)
 
 PRODUCT_NAME := Nightmare
-PRODUCT_DEVICE := nightmare
+PRODUCT_DEVICE := treble_arm64_bvN
 PRODUCT_BRAND := realme
 PRODUCT_MODEL := nightmare
 


### PR DESCRIPTION
build/make/core/product_config.mk:247: error: No matches for product "treble_arm64_bvN".

Lel

Reference : `https://github.com/ninjapika/android_device_xiaomi_certus64/commit/ff9b1d559320b3dc2244ced309eda0f2ffa28bc8`